### PR TITLE
Makes Modular.AreaAccess.define_mocks/0 idempotent again

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :modular, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:modular, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env()}.exs"
+config :modular, :areas, [Modular.Test.Area]

--- a/lib/modular/area_access.ex
+++ b/lib/modular/area_access.ex
@@ -112,7 +112,7 @@ defmodule Modular.AreaAccess do
            ) do
         {:ok, _} -> :ok
         {:error, {:already_started, _}} -> :ok
-        _ -> raise "Could not start area cache"
+        {:error, reason} -> raise "Could not start area cache: #{inspect(reason)}"
       end
     end
 

--- a/lib/modular/area_access.ex
+++ b/lib/modular/area_access.ex
@@ -99,8 +99,6 @@ defmodule Modular.AreaAccess do
   defmodule AreasCache do
     @moduledoc false
 
-    use Agent
-
     def start! do
       case Agent.start_link(
              fn ->

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Modular.MixProject do
       version: @version,
       elixir: "~> 1.7",
       deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env()),
 
       # Hex
       description: @desc,
@@ -35,6 +36,9 @@ defmodule Modular.MixProject do
       {:mox, ">= 0.0.0", optional: true}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp package do
     [

--- a/test/modular/area_access_test.exs
+++ b/test/modular/area_access_test.exs
@@ -1,0 +1,26 @@
+defmodule Modular.AreaAccessTest do
+  use ExUnit.Case
+  doctest Modular.AreaAccess
+
+  describe "define_mocks/0" do
+    test "defines mock modules for behaviours" do
+      Modular.AreaAccess.define_mocks()
+      assert Code.ensure_loaded?(Modular.Test.Area.Mock)
+    end
+
+    test "is idempotent" do
+      Modular.AreaAccess.define_mocks()
+      Modular.AreaAccess.define_mocks()
+    end
+  end
+
+  describe "install_stubs/0" do
+    test "stubs all functions with real implementations" do
+      Modular.AreaAccess.define_mocks()
+      Modular.AreaAccess.install_stubs()
+      assert Code.ensure_loaded?(Modular.Test.Area.Mock)
+      assert Modular.Test.Area.Mock.greet("Bob") == "Hello, Bob"
+      assert Modular.Test.Area.Mock.incr(5) == 6
+    end
+  end
+end

--- a/test/support/area/area.ex
+++ b/test/support/area/area.ex
@@ -1,0 +1,6 @@
+defmodule Modular.Test.Area do
+  @moduledoc false
+
+  @callback greet(String.t()) :: String.t()
+  @callback incr(integer()) :: integer()
+end

--- a/test/support/area/impl.ex
+++ b/test/support/area/impl.ex
@@ -1,0 +1,11 @@
+defmodule Modular.Test.Area.Impl do
+  @moduledoc false
+
+  @behaviour Modular.Test.Area
+
+  @impl true
+  def greet(name), do: "Hello, #{name}"
+
+  @impl true
+  def incr(num), do: num + 1
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Application.ensure_all_started(:mox)
 ExUnit.start()


### PR DESCRIPTION
In v0.3.1 I've broken `Modular.AreaAccess.define_mocks/0` so that when used repeatedly (which can be the case for e.g. umbrella tests) it would crash. This PR fixes that issue, also extracting the area cache agent to a separate module and adding some unit tests to make sure it works.